### PR TITLE
commands: Add missing error check for stats command.

### DIFF
--- a/commands/info.go
+++ b/commands/info.go
@@ -24,7 +24,6 @@ func Info() {
 	}
 
 	font, err := sfnt.Parse(bytes.NewReader(data))
-
 	if err != nil {
 		panic(err)
 	}

--- a/commands/metrics.go
+++ b/commands/metrics.go
@@ -23,7 +23,6 @@ func Metrics() {
 	}
 
 	font, err := sfnt.Parse(bytes.NewReader(data))
-
 	if err != nil {
 		panic(err)
 	}

--- a/commands/scrub.go
+++ b/commands/scrub.go
@@ -22,7 +22,6 @@ func Scrub() {
 	}
 
 	font, err := sfnt.Parse(bytes.NewReader(data))
-
 	if err != nil {
 		panic(err)
 	}

--- a/commands/stats.go
+++ b/commands/stats.go
@@ -23,6 +23,9 @@ func Stats() {
 	}
 
 	font, err := sfnt.Parse(bytes.NewReader(data))
+	if err != nil {
+		panic(err)
+	}
 
 	for _, tag := range font.Tags() {
 		table := font.Table(tag)


### PR DESCRIPTION
The stats command did not check the error returned by `sfnt.Parse`. Fix that.

Also remove blank line between function call and associated error check. This is more idiomatic Go style. It's more readable because it's easier to see that the error is being checked (rather than being ignored).

(This is a small PR to test the waters and find out whether this repository is still actively maintained, etc.)