### PR TITLE
Refactor the commands so they accept a sfnt.Font, and return a error.

### DIFF
--- a/commands/features.go
+++ b/commands/features.go
@@ -2,33 +2,22 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/ConradIrwin/font/sfnt"
 )
 
 // Features prints the gpos/gsub tables (contains font features).
-func Features() {
-	if len(os.Args) < 2 {
-		panic(fmt.Errorf("Specify a font file"))
+func Features(font *sfnt.Font) error {
+	if err := layoutTable(font, sfnt.TagGsub, "Glyph Substitution Table (GSUB)"); err != nil {
+		return err
 	}
-
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		panic(fmt.Errorf("Failed to open font: %s", err))
+	if err := layoutTable(font, sfnt.TagGpos, "Glyph Positioning Table (GPOS)"); err != nil {
+		return err
 	}
-	defer file.Close()
-
-	font, err := sfnt.Parse(file)
-	if err != nil {
-		panic(fmt.Errorf("Failed to parse font: %s", err))
-	}
-
-	layoutTable(font, sfnt.TagGsub, "Glyph Substitution Table (GSUB)")
-	layoutTable(font, sfnt.TagGpos, "Glyph Positioning Table (GPOS)")
+	return nil
 }
 
-func layoutTable(font *sfnt.Font, tag sfnt.Tag, name string) {
+func layoutTable(font *sfnt.Font, tag sfnt.Tag, name string) error {
 	if font.HasTable(tag) {
 		fmt.Printf("%s:\n", name)
 
@@ -51,6 +40,8 @@ func layoutTable(font *sfnt.Font, tag sfnt.Tag, name string) {
 	} else {
 		fmt.Printf("No %s\n", name)
 	}
+
+	return nil
 }
 
 func bracketString(o fmt.Stringer) string {

--- a/commands/info.go
+++ b/commands/info.go
@@ -1,32 +1,13 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 
 	"github.com/ConradIrwin/font/sfnt"
 )
 
-func Info() {
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-
-	data, err := ioutil.ReadFile(file.Name())
-	if err != nil {
-		panic(err)
-	}
-
-	font, err := sfnt.Parse(bytes.NewReader(data))
-	if err != nil {
-		panic(err)
-	}
-
+func Info(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagName) {
 		name := font.NameTable()
 
@@ -35,4 +16,5 @@ func Info() {
 			fmt.Println(entry.Platform() + ids + entry.Label() + ": " + entry.String())
 		}
 	}
+	return nil
 }

--- a/commands/metrics.go
+++ b/commands/metrics.go
@@ -1,32 +1,12 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/ConradIrwin/font/sfnt"
 )
 
-func Metrics() {
-
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-
-	data, err := ioutil.ReadFile(file.Name())
-	if err != nil {
-		panic(err)
-	}
-
-	font, err := sfnt.Parse(bytes.NewReader(data))
-	if err != nil {
-		panic(err)
-	}
-
+func Metrics(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagHhea) {
 		hhea := font.HheaTable()
 		fmt.Println("Ascent:", hhea.Ascent)
@@ -52,6 +32,7 @@ func Metrics() {
 		fmt.Println("Win Descent:", os2.UsWinDescent)
 
 		fmt.Println("TODO: SHOW MORE METRICS")
-
 	}
+
+	return nil
 }

--- a/commands/scrub.go
+++ b/commands/scrub.go
@@ -1,34 +1,15 @@
 package commands
 
 import (
-	"bytes"
-	"io/ioutil"
-	"os"
-
 	"github.com/ConradIrwin/font/sfnt"
+	"os"
 )
 
-func Scrub() {
-
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-
-	data, err := ioutil.ReadFile(file.Name())
-	if err != nil {
-		panic(err)
-	}
-
-	font, err := sfnt.Parse(bytes.NewReader(data))
-	if err != nil {
-		panic(err)
-	}
-
+func Scrub(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagName) {
 		font.AddTable(sfnt.TagName, sfnt.NewTableName())
 	}
 
-	font.WriteOTF(os.Stdout)
+	_, err := font.WriteOTF(os.Stdout)
+	return err
 }

--- a/commands/stats.go
+++ b/commands/stats.go
@@ -1,35 +1,15 @@
 package commands
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
 
 	"github.com/ConradIrwin/font/sfnt"
 )
 
-func Stats() {
-
-	file, err := os.Open(os.Args[1])
-	if err != nil {
-		panic(err)
-	}
-	defer file.Close()
-
-	data, err := ioutil.ReadFile(file.Name())
-	if err != nil {
-		panic(err)
-	}
-
-	font, err := sfnt.Parse(bytes.NewReader(data))
-	if err != nil {
-		panic(err)
-	}
-
+func Stats(font *sfnt.Font) error {
 	for _, tag := range font.Tags() {
 		table := font.Table(tag)
 		fmt.Println(tag, len(table.Bytes()))
 	}
-
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -5,30 +5,21 @@ import (
 	"os"
 
 	"github.com/ConradIrwin/font/commands"
+	"github.com/ConradIrwin/font/sfnt"
 )
 
-func main() {
+type Command func(*sfnt.Font) error
 
-	command := "help"
+var cmds = map[string]Command{
+	"scrub":    commands.Scrub,
+	"info":     commands.Info,
+	"stats":    commands.Stats,
+	"metrics":  commands.Metrics,
+	"features": commands.Features,
+}
 
-	if len(os.Args) > 1 {
-		command = os.Args[1]
-		os.Args = os.Args[1:]
-	}
-
-	switch command {
-	case "scrub":
-		commands.Scrub()
-	case "info":
-		commands.Info()
-	case "stats":
-		commands.Stats()
-	case "metrics":
-		commands.Metrics()
-	case "features":
-		commands.Features()
-	default:
-		fmt.Println(`
+func usage() {
+	fmt.Println(`
 Usage: font [features|info|metrics|scrub|stats] font.[otf,ttf,woff]
 
 features: prints the gpos/gsub tables (contains font features)
@@ -36,6 +27,41 @@ info: prints the name table (contains metadata)
 metrics: prints the hhea table (contains font metrics)
 scrub: remove the name table (saves significant space)
 stats: prints each table and the amount of space used`)
+}
+
+func main() {
+	command := "help"
+	if len(os.Args) > 1 {
+		command = os.Args[1]
+		os.Args = os.Args[1:]
 	}
 
+	if _, found := cmds[command]; !found {
+		usage()
+		return
+	}
+
+	if len(os.Args) < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: font %s <font file>\n", command)
+		os.Exit(1)
+	}
+
+	filename := os.Args[1]
+	file, err := os.Open(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open font: %s\n", err)
+		os.Exit(1)
+	}
+	defer file.Close()
+
+	font, err := sfnt.Parse(file)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to parse font: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := cmds[command](font); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This reduces the amount of code (at the cost of making commands less flexible).

It is the first step to removing all the panics from the code.