### PR TITLE
Changed the Tables Bytes() methods to never panic,

### DIFF
--- a/commands/features.go
+++ b/commands/features.go
@@ -29,10 +29,10 @@ func Features() {
 }
 
 func layoutTable(font *sfnt.Font, tag sfnt.Tag, name string) {
-	if font.HasTable(tag) {
+	t, found := font.Table(tag)
+	if t, ok := t.(*sfnt.TableLayout); found && ok {
 		fmt.Printf("%s:\n", name)
 
-		t := font.Table(tag).(*sfnt.TableLayout)
 		for _, script := range t.Scripts {
 			fmt.Printf("\tScript %q%s:\n", script.Tag, bracketString(script))
 

--- a/commands/info.go
+++ b/commands/info.go
@@ -27,12 +27,12 @@ func Info() {
 		panic(err)
 	}
 
-	if font.HasTable(sfnt.TagName) {
-		name := font.NameTable()
-
+	if name, ok := font.NameTable(); ok {
 		for _, entry := range name.List() {
 			ids := " (" + strconv.Itoa(int(entry.PlatformID)) + "," + strconv.Itoa(int(entry.EncodingID)) + "," + strconv.Itoa(int(entry.LanguageID)) + "," + strconv.Itoa(int(entry.NameID)) + ") "
 			fmt.Println(entry.Platform() + ids + entry.Label() + ": " + entry.String())
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "Missing %q table\n", sfnt.TagName.String())
 	}
 }

--- a/commands/metrics.go
+++ b/commands/metrics.go
@@ -27,8 +27,7 @@ func Metrics() {
 		panic(err)
 	}
 
-	if font.HasTable(sfnt.TagHhea) {
-		hhea := font.HheaTable()
+	if hhea, ok := font.HheaTable(); ok {
 		fmt.Println("Ascent:", hhea.Ascent)
 		fmt.Println("Descent:", hhea.Descent)
 		fmt.Println("Line gap:", hhea.LineGap)
@@ -38,12 +37,12 @@ func Metrics() {
 		fmt.Println("Advance with max:", hhea.AdvanceWidthMax)
 		fmt.Println("Min left side bearing:", hhea.MinLeftSideBearing)
 		fmt.Println("Min right side bearing:", hhea.MinRightSideBearing)
+	} else {
+		fmt.Fprintf(os.Stderr, "No %q table\n", sfnt.TagHhea.String())
 	}
 
-	if font.HasTable(sfnt.TagOS2) {
-		fmt.Printf("%#v\n", font.OS2Table())
-
-		os2 := font.OS2Table()
+	if os2, ok := font.OS2Table(); ok {
+		fmt.Printf("%#v\n", os2)
 
 		fmt.Println("Cap Height:", os2.SCapHeight)
 		fmt.Println("Typographic Ascender:", os2.STypoAscender)
@@ -52,6 +51,7 @@ func Metrics() {
 		fmt.Println("Win Descent:", os2.UsWinDescent)
 
 		fmt.Println("TODO: SHOW MORE METRICS")
-
+	} else {
+		fmt.Fprintf(os.Stderr, "No %q table\n", sfnt.TagOS2.String())
 	}
 }

--- a/commands/stats.go
+++ b/commands/stats.go
@@ -28,8 +28,8 @@ func Stats() {
 	}
 
 	for _, tag := range font.Tags() {
-		table := font.Table(tag)
-		fmt.Println(tag, len(table.Bytes()))
+		if table, ok := font.Table(tag); ok {
+			fmt.Println(tag, len(table.Bytes()))
+		}
 	}
-
 }

--- a/sfnt/font.go
+++ b/sfnt/font.go
@@ -99,46 +99,46 @@ func (font *Font) String() string {
 }
 
 // HeadTable returns the table corresponding to the 'head' tag.
-// This method will panic if the font does not have this table,
-// or if it is not an instance of TableHead.
-func (font *Font) HeadTable() *TableHead {
-	return font.tables[TagHead].(*TableHead)
+func (font *Font) HeadTable() (*TableHead, bool) {
+	t, found := font.tables[TagHead].(*TableHead)
+	return t, found
 }
 
 // NameTable returns the table corresponding to the 'name' tag.
-// This method will panic if the font does not have this table,
-// or if it is not an instance of TableName.
-func (font *Font) NameTable() *TableName {
-	return font.tables[TagName].(*TableName)
+func (font *Font) NameTable() (*TableName, bool) {
+	t, found := font.tables[TagName].(*TableName)
+	return t, found
 }
 
-func (font *Font) HheaTable() *TableHhea {
-	return font.tables[TagHhea].(*TableHhea)
+func (font *Font) HheaTable() (*TableHhea, bool) {
+	t, found := font.tables[TagHhea].(*TableHhea)
+	return t, found
 }
 
-func (font *Font) OS2Table() *TableOS2 {
-	return font.tables[TagOS2].(*TableOS2)
+func (font *Font) OS2Table() (*TableOS2, bool) {
+	t, found := font.tables[TagOS2].(*TableOS2)
+	return t, found
 }
 
 // GposTable returns the Glyph Positioning table identified with the 'GPOS' tag.
-// This method will panic if the font doesn't have this table.
-func (font *Font) GposTable() *TableLayout {
-	return font.tables[TagGpos].(*TableLayout)
+func (font *Font) GposTable() (*TableLayout, bool) {
+	t, found := font.tables[TagGpos].(*TableLayout)
+	return t, found
 }
 
 // GsubTable returns the Glyph Substitution table identified with the 'GSUB' tag.
-// This method will panic if the font doesn't have this table.
-func (font *Font) GsubTable() *TableLayout {
-	return font.tables[TagGsub].(*TableLayout)
+func (font *Font) GsubTable() (*TableLayout, bool) {
+	t, found := font.tables[TagGsub].(*TableLayout)
+	return t, found
 }
 
-func (font *Font) Table(tag Tag) Table {
-	return font.tables[tag]
+func (font *Font) Table(tag Tag) (Table, bool) {
+	t, found := font.tables[tag]
+	return t, found
 }
 
 func (font *Font) checkSum() uint32 {
-
-	total := uint32(0)
+	var total uint32
 
 	for _, table := range font.tables {
 		total += checkSum(table.Bytes())

--- a/sfnt/table_feature_test.go
+++ b/sfnt/table_feature_test.go
@@ -22,7 +22,7 @@ func TestFeatureString(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		f := Feature{Tag: NamedTag(test.tag)}
+		f := Feature{Tag: MustNamedTag(test.tag)}
 		if got := f.String(); got != test.want {
 			t.Errorf("Feature{%q}.String() = %q want %q", test.tag, got, test.want)
 		}

--- a/sfnt/table_head.go
+++ b/sfnt/table_head.go
@@ -39,11 +39,9 @@ func parseTableHead(buffer io.Reader) (*TableHead, error) {
 
 // Bytes returns the byte representation of this header.
 func (table *TableHead) Bytes() []byte {
-	buffer := &bytes.Buffer{}
-	err := binary.Write(buffer, binary.BigEndian, table)
-	// should never happen
-	if err != nil {
-		panic(err)
+	var buffer bytes.Buffer
+	if err := binary.Write(&buffer, binary.BigEndian, table); err != nil {
+		panic(err) // should never happen
 	}
 	return buffer.Bytes()
 }

--- a/sfnt/table_hhea.go
+++ b/sfnt/table_hhea.go
@@ -37,11 +37,10 @@ func parseTableHhea(buffer io.Reader) (*TableHhea, error) {
 
 // Bytes returns the byte representation of this header.
 func (table *TableHhea) Bytes() []byte {
-	buffer := &bytes.Buffer{}
-	err := binary.Write(buffer, binary.BigEndian, table)
-	// should never happen
-	if err != nil {
-		panic(err)
+	var buffer bytes.Buffer
+	if err := binary.Write(&buffer, binary.BigEndian, table); err != nil {
+		panic(err) // should never happen
+
 	}
 	return buffer.Bytes()
 }

--- a/sfnt/tag.go
+++ b/sfnt/tag.go
@@ -1,38 +1,41 @@
 package sfnt
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+	"fmt"
+)
 
 var (
 	// TagHead represents the 'head' table, which contains the font header
-	TagHead = NamedTag("head")
+	TagHead = MustNamedTag("head")
 	// TagMaxp represents the 'maxp' table, which contains the maximum profile
-	TagMaxp = NamedTag("maxp")
+	TagMaxp = MustNamedTag("maxp")
 	// TagHmtx represents the 'hmtx' table, which contains the horizontal metrics
-	TagHmtx = NamedTag("hmtx")
+	TagHmtx = MustNamedTag("hmtx")
 	// TagHhea represents the 'hhea' table, which contains the horizonal header
-	TagHhea = NamedTag("hhea")
+	TagHhea = MustNamedTag("hhea")
 	// TagOS2 represents the 'OS/2' table, which contains windows-specific metadata
-	TagOS2 = NamedTag("OS/2")
+	TagOS2 = MustNamedTag("OS/2")
 	// TagName represents the 'name' table, which contains font name information
-	TagName = NamedTag("name")
+	TagName = MustNamedTag("name")
 	// TagGpos represents the 'GPOS' table, which contains Glyph Positioning features
-	TagGpos = NamedTag("GPOS")
+	TagGpos = MustNamedTag("GPOS")
 	// TagGsub represents the 'GSUB' table, which contains Glyph Substitution features
-	TagGsub = NamedTag("GSUB")
+	TagGsub = MustNamedTag("GSUB")
 
 	// TypeTrueType is the first four bytes of an OpenType file containing a TrueType font
 	TypeTrueType = Tag{0x00010000}
 	// TypeAppleTrueType is the first four bytes of an OpenType file containing a TrueType font
 	// (specifically one designed for Apple products, it's recommended to use TypeTrueType instead)
-	TypeAppleTrueType = NamedTag("true")
+	TypeAppleTrueType = MustNamedTag("true")
 	// TypePostScript1 is the first four bytes of an OpenType file containing a PostScript Type 1 font
-	TypePostScript1 = NamedTag("typ1")
+	TypePostScript1 = MustNamedTag("typ1")
 	// TypeOpenType is the first four bytes of an OpenType file containing a PostScript Type 2 font
 	// as specified by OpenType
-	TypeOpenType = NamedTag("OTTO")
+	TypeOpenType = MustNamedTag("OTTO")
 
 	// SignatureWoff if the magic number at the start of a wOFF file.
-	SignatureWoff = NamedTag("wOFF")
+	SignatureWoff = MustNamedTag("wOFF")
 )
 
 // Tag represents an open-type table name.
@@ -44,19 +47,27 @@ type Tag struct {
 }
 
 // NamedTag gives you the Tag corresponding to the acronym.
-// This function will panic if the string passed in is not 4 bytes long.
-func NamedTag(str string) Tag {
+func NamedTag(str string) (Tag, error) {
 	bytes := []byte(str)
 
 	if len(bytes) != 4 {
-		panic("invalid tag")
+		return Tag{}, fmt.Errorf("invalid tag: must be exactly 4 bytes")
 	}
 
 	return Tag{uint32(bytes[0])<<24 |
 		uint32(bytes[1])<<16 |
 		uint32(bytes[2])<<8 |
-		uint32(bytes[3])}
+		uint32(bytes[3])}, nil
+}
 
+// MustNamedTag gives you the Tag corresponding to the acronym.
+// This function will panic if the string passed in is not 4 bytes long.
+func MustNamedTag(str string) Tag {
+	t, err := NamedTag(str)
+	if err != nil {
+		panic(err)
+	}
+	return t
 }
 
 // String returns the ASCII representation of the tag.

--- a/sfnt/tag_test.go
+++ b/sfnt/tag_test.go
@@ -3,8 +3,7 @@ package sfnt
 import "testing"
 
 func TestParsedTag(t *testing.T) {
-
-	tag := NamedTag("head")
+	tag := MustNamedTag("head")
 	if tag.Number != 0x68656164 {
 		t.Errorf("head != %v", tag.Number)
 	}
@@ -15,7 +14,6 @@ func TestParsedTag(t *testing.T) {
 }
 
 func TestNewTag(t *testing.T) {
-
 	tag := Tag{0x74727565}
 
 	if tag.Number != 0x74727565 {
@@ -28,7 +26,6 @@ func TestNewTag(t *testing.T) {
 }
 
 func TestTagEquality(t *testing.T) {
-
 	t1 := Tag{0x74727565}
 	t2 := Tag{0x74727565}
 
@@ -36,12 +33,11 @@ func TestTagEquality(t *testing.T) {
 		t.Errorf("equality failed for number")
 	}
 
-	if NamedTag("head") != NamedTag("head") {
+	if MustNamedTag("head") != MustNamedTag("head") {
 		t.Errorf("equality failed for parsed")
 	}
 
-	if NamedTag("true") != t1 {
-		t.Errorf("equality failed %v %v", NamedTag("true"), t1)
+	if MustNamedTag("true") != t1 {
+		t.Errorf("equality failed %v %v", MustNamedTag("true"), t1)
 	}
-
 }

--- a/sfnt/write_otf.go
+++ b/sfnt/write_otf.go
@@ -2,6 +2,7 @@ package sfnt
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"sort"
 )
@@ -43,7 +44,10 @@ func (font *Font) WriteOTF(w io.Writer) (n int, err error) {
 	todo := outputEntries(font.Tags())
 	sort.Sort(todo)
 
-	headTable := font.HeadTable()
+	headTable, ok := font.HeadTable()
+	if !ok {
+		return 0, fmt.Errorf("missing `head` table")
+	}
 
 	headTable.ClearExpectedChecksum()
 


### PR DESCRIPTION
Instead the table parsers do the work upfront and throw a error during the original parsing.

Specifically:
1) Moved the TableName list parsing into parseTableName. Doing a full parse early does have its down sides, but simplifies the API. So I think its a net win.
2) Refactored TableName struct a little so its nil value is the default (empty table).
3) A bunch of other minor style changes, ie `var buf bytes.Buffer` instead of `buf := &bytes.Buffer{}`.