### PR TITLE
Move font to cmd/font; merge commands into it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-A program for parsing OpenType fonts in Golang.
+A collection of Go packages for parsing and encoding OpenType fonts.
 
 The main contribution of this repository is the [SFNT](https://godoc.org/github.com/ConradIrwin/font/sfnt) library which provides support for parsing OpenType, TrueType and wOFF fonts.
 
-Also included is a sample program called `font` that can do various useful things with fonts:
+Also included is a utility called `font` that can do various useful things with fonts:
 
 ```
-go install github.com/ConradIrwin/font
+go get -u github.com/ConradIrwin/font/cmd/font
 ```
 
 Info gets information about the font from the `name` table:
+
 ```
 font info ~/Downloads/Fanwood.ttf
 ```
@@ -45,4 +46,3 @@ License
 =======
 
 Copyright (c) Conrad Irwin 2015, MIT license. See LICENSE.MIT for details
-

--- a/cmd/font/features.go
+++ b/cmd/font/features.go
@@ -1,4 +1,4 @@
-package commands
+package main
 
 import (
 	"fmt"

--- a/cmd/font/info.go
+++ b/cmd/font/info.go
@@ -1,4 +1,4 @@
-package commands
+package main
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"github.com/ConradIrwin/font/sfnt"
 )
 
+// Info prints the name table (contains metadata).
 func Info(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagName) {
 		name, err := font.NameTable()

--- a/cmd/font/main.go
+++ b/cmd/font/main.go
@@ -1,22 +1,12 @@
+// font is a utility that can parse and print information about font files.
 package main
 
 import (
 	"fmt"
 	"os"
 
-	"github.com/ConradIrwin/font/commands"
 	"github.com/ConradIrwin/font/sfnt"
 )
-
-type Command func(*sfnt.Font) error
-
-var cmds = map[string]Command{
-	"scrub":    commands.Scrub,
-	"info":     commands.Info,
-	"stats":    commands.Stats,
-	"metrics":  commands.Metrics,
-	"features": commands.Features,
-}
 
 func usage() {
 	fmt.Println(`
@@ -36,6 +26,13 @@ func main() {
 		os.Args = os.Args[1:]
 	}
 
+	cmds := map[string]func(*sfnt.Font) error{
+		"scrub":    Scrub,
+		"info":     Info,
+		"stats":    Stats,
+		"metrics":  Metrics,
+		"features": Features,
+	}
 	if _, found := cmds[command]; !found {
 		usage()
 		return

--- a/cmd/font/metrics.go
+++ b/cmd/font/metrics.go
@@ -1,4 +1,4 @@
-package commands
+package main
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/ConradIrwin/font/sfnt"
 )
 
+// Metrics prints the hhea table (contains font metrics).
 func Metrics(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagHhea) {
 		hhea, err := font.HheaTable()

--- a/cmd/font/scrub.go
+++ b/cmd/font/scrub.go
@@ -1,10 +1,12 @@
-package commands
+package main
 
 import (
-	"github.com/ConradIrwin/font/sfnt"
 	"os"
+
+	"github.com/ConradIrwin/font/sfnt"
 )
 
+// Scrub remove the name table (saves significant space).
 func Scrub(font *sfnt.Font) error {
 	if font.HasTable(sfnt.TagName) {
 		font.AddTable(sfnt.TagName, sfnt.NewTableName())

--- a/cmd/font/stats.go
+++ b/cmd/font/stats.go
@@ -1,4 +1,4 @@
-package commands
+package main
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"github.com/ConradIrwin/font/sfnt"
 )
 
+// Stats prints each table and the amount of space used.
 func Stats(font *sfnt.Font) error {
 	for _, tag := range font.Tags() {
 		table, err := font.Table(tag)


### PR DESCRIPTION
This change simplifies the overall project and makes it more consistent with other high quality idiomatic Go repositories.

Removing the commands package reduces the public facing API surface, making it so that whatever API is left is higher quality, more useful. This should be helpful to people who are discovering the project for the first time and reading its documentation.

Resolves #10.