### PR TITLE
Support multiple font files in commands

### DIFF
--- a/cmd/font/main.go
+++ b/cmd/font/main.go
@@ -10,7 +10,7 @@ import (
 
 func usage() {
 	fmt.Println(`
-Usage: font [features|info|metrics|scrub|stats] font.[otf,ttf,woff,woff2]
+Usage: font [features|info|metrics|scrub|stats] font.[otf,ttf,woff,woff2] ...
 
 features: prints the gpos/gsub tables (contains font features)
 info: prints the name table (contains metadata)
@@ -39,26 +39,30 @@ func main() {
 	}
 
 	if len(os.Args) < 1 {
-		fmt.Fprintf(os.Stderr, "Usage: font %s <font file>\n", command)
+		fmt.Fprintf(os.Stderr, "Usage: font %s <font file> ...\n", command)
 		os.Exit(1)
 	}
 
-	filename := os.Args[1]
-	file, err := os.Open(filename)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to open font: %s\n", err)
-		os.Exit(1)
-	}
-	defer file.Close()
+	for _, filename := range os.Args[1:] {
+		file, err := os.Open(filename)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to open font: %s\n", err)
+			os.Exit(1)
+		}
+		defer file.Close()
 
-	font, err := sfnt.Parse(file)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to parse font: %s\n", err)
-		os.Exit(1)
-	}
+		font, err := sfnt.Parse(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse font: %s\n", err)
+			os.Exit(1)
+		}
 
-	if err := cmds[command](font); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
-		os.Exit(1)
+		if len(os.Args[1:]) > 1 {
+			fmt.Println("==>", filename, "<==")
+		}
+		if err := cmds[command](font); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/font/main.go
+++ b/cmd/font/main.go
@@ -43,18 +43,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	exitCode := 0
 	for _, filename := range os.Args[1:] {
 		file, err := os.Open(filename)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to open font: %s\n", err)
-			os.Exit(1)
+			exitCode = 1
+			continue
 		}
 		defer file.Close()
 
 		font, err := sfnt.Parse(file)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to parse font: %s\n", err)
-			os.Exit(1)
+			exitCode = 1
+			continue
 		}
 
 		if len(os.Args[1:]) > 1 {
@@ -62,7 +65,9 @@ func main() {
 		}
 		if err := cmds[command](font); err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
+			exitCode = 1
+			continue
 		}
 	}
+	os.Exit(exitCode)
 }


### PR DESCRIPTION
I was dumping metrics on a few dozen font files so added support for `font <command> *.<ext>` without having to resort to shell loops or `xargs`. When multiple files are passed I used `==> filename <==` header that `head` and `tail` use.